### PR TITLE
Remove test for API_TOKEN in tag list

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - main
+      - patch-1
   pull_request:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - patch-1
+      - main
   pull_request:
     branches:
       - main

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -26,16 +26,11 @@ sort_versions() {
 }
 
 list_github_tags() {
-  if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-    git ls-remote --tags --refs "$GH_REPO" |
-      grep -oE 'refs/tags/v[0-9]+.[0-9]+.[0-9]+$' |
-      cut -d/ -f3- |
-      sed 's/^v//' |
-      sort -V
-  else
-    # If we can't use the GitHub API, we'll just hardcode the latest version
-    echo "14.2.2"
-  fi
+  git ls-remote --tags --refs "$GH_REPO" |
+    grep -oE 'refs/tags/v[0-9]+.[0-9]+.[0-9]+$' |
+    cut -d/ -f3- |
+    sed 's/^v//' |
+    sort -V
 }
 
 list_all_versions() {


### PR DESCRIPTION
Remove test for `GITHUB_API_TOKEN` in `list_github_tags` function to avoid hardcoding a single version.
Fixes #25 