### PR TITLE
fix: MacOS install for app bundles.

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -111,7 +111,7 @@ install_client_binary() {
   if [ ! -f "$binary_path" -a -d "${binary_path}.app" ]; then
     # Hanle MacOS application bundle.
     mv "${binary_path}.app" "$install_path/bin/${binary}.app"
-    ( cd "$install_path/bin" && ln -s "${binary}.app/Contents/MacOS/$binary" "$binary" )
+    (cd "$install_path/bin" && ln -s "${binary}.app/Contents/MacOS/$binary" "$binary")
   else
     mv "$binary_path" "$install_path/bin/$binary"
   fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -111,7 +111,7 @@ install_client_binary() {
   if [ ! -f "$binary_path" -a -d "${binary_path}.app" ]; then
     # Hanle MacOS application bundle.
     mv "${binary_path}.app" "$install_path/bin/${binary}.app"
-    ( cd "$install_path/bin" && ln -s "$binary" "${binary}.app/Contents/MacOS/$binary" )
+    ( cd "$install_path/bin" && ln -s "${binary}.app/Contents/MacOS/$binary" "$binary" )
   else
     mv "$binary_path" "$install_path/bin/$binary"
   fi


### PR DESCRIPTION
This change fixes a problem with installing MacOS app bundles that was introduced in #30. Apologies for the problem!