### PR TITLE
fix: Linux/ARM64 install.

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -10,7 +10,7 @@ OS="${OS:-unknown}"
 ARCH="${ARCH:-unknown}"
 
 fail() {
-  echo -e "asdf-$TOOL_NAME: $*"
+  echo -e "asdf-$TOOL_NAME: $*" >/dev/stderr
   exit 1
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -78,6 +78,8 @@ detect_arch() {
       echo "$ARCH"
     elif [ "${ARCH}" == "arm64" ]; then
       echo "$ARCH"
+    elif [ "${ARCH}" == "aarch64" ]; then
+      echo "arm64"
     elif [ "${ARCH}" == "i386" ]; then
       echo "$ARCH"
     elif [ "${ARCH}" == "armv7" ]; then


### PR DESCRIPTION
This change fixes the Teleport install on ARM 64 bit Linux deployments. On 64 bit ARM, Linux reports the result of `uname -m` as `aarch64`. The change also modifies the `fail()` helper function to send diagnostic output to stderr. 

Without this change, an attempt to install Teleport on a Linux on Mac results in this error message:
```
error installing version: failed to run download callback: exit status 1
```
That's not a lot, but if I instrument `lib/utils.bash` to print the debug output, the result is this:
```
++ set -euo pipefail
++ GH_REPO=https://github.com/gravitational/teleport/
++ REPO=https://cdn.teleport.dev
++ TOOL_NAME=teleport-ent
++ TOOL_TEST='tsh version'
++ OS=unknown
++ ARCH=unknown
++ curl_opts=(-fsSL)
++ '[' -n '' ']'
+ mkdir -p /root/.asdf/downloads/teleport/16.1.0
+ release_file=/root/.asdf/downloads/teleport/16.1.0/teleport-ent-16.1.0.tar.gz
+ download_release 16.1.0 /root/.asdf/downloads/teleport/16.1.0/teleport-ent-16.1.0.tar.gz
+ local version filename url
+ version=16.1.0
+ filename=/root/.asdf/downloads/teleport/16.1.0/teleport-ent-16.1.0.tar.gz
++ detect_os
++ '[' unknown = unknown ']'
+++ command -v uname
++ UNAME=/usr/bin/uname
++ case $("${UNAME}" | tr '[:upper:]' '[:lower:]') in
+++ /usr/bin/uname
+++ tr '[:upper:]' '[:lower:]'
++ echo linux
+ os=linux
++ detect_arch linux
++ '[' unknown = unknown ']'
+++ uname -m
++ ARCH=aarch64
++ '[' 0 '!=' 0 ']'
++ '[' aarch64 == x86_64 ']'
++ '[' aarch64 == amd64 ']'
++ '[' aarch64 == arm64 ']'
++ '[' aarch64 == i386 ']'
++ '[' aarch64 == armv7 ']'
++ fail 'Unknown architecture. Please provide the architecture by setting $ARCH.'
++ echo -e 'asdf-teleport-ent: Unknown architecture. Please provide the architecture by setting $ARCH.'
++ exit 1
+ arch='asdf-teleport-ent: Unknown architecture. Please provide the architecture by setting $ARCH.'
error installing version: failed to run download callback: exit status 1
```
As you can see, there is a clear diagnostic reported, but it is captured in the variable instead, so sending it to stderr will surface it.