### PR TITLE
feat: Allow -fips Versions of teleport-ent cli

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -13,8 +13,14 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 # TODO: Adapt this to proper extension and adapt extracting strategy.
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 
+fips_build=false
+if [[ "$ASDF_INSTALL_VERSION" == *-fips ]]; then
+    ASDF_INSTALL_VERSION="${ASDF_INSTALL_VERSION%-fips}"
+    fips_build=true
+fi
+
 # Download tar.gz file to the download directory
-download_release "$ASDF_INSTALL_VERSION" "$release_file"
+download_release "$ASDF_INSTALL_VERSION" "$release_file" "$fips_build"
 
 #  Extract contents of tar.gz file into the download directory
 tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -93,14 +93,20 @@ detect_arch() {
 }
 
 download_release() {
-  local version filename url
+  local version filename url fips
   version="$1"
   filename="$2"
+  fips_build="$3"
   os=$(detect_os)
   arch=$(detect_arch "$os")
-  url="$REPO/teleport-ent-v${version}-${os}-${arch}-bin.tar.gz"
 
-  echo "* Downloading $TOOL_NAME release $version..."
+  if [[ "$fips_build" == true ]]; then
+    url="$REPO/teleport-ent-v${version}-${os}-${arch}-fips-bin.tar.gz"
+  else
+    url="$REPO/teleport-ent-v${version}-${os}-${arch}-bin.tar.gz"
+  fi
+
+  echo "* Downloading $TOOL_NAME release $version (fips=$fips_build)..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
 }
 


### PR DESCRIPTION
feat:
Allow installing of `-fips` versions of teleport cli.

resolves:
#37 

testing:
I attempted testing, however the `asdf plugin test` functionality seems broken in the latest asdf tool version (I'm using asdf `v0.16.7`) and does not want to accept my parameters for testing installation of various tool versions... tried a whole lot of different combinations (with and without quotes, various syntaxes, setting env vars) that all failed to try and test any other version besides an antique one... hopefully the git pr workflow can run some tests? Or if someone can point me to what I'm doing wrong as far as trying to test?
```
$ asdf plugin test v6 https://github.com/drootsad/asdf-teleport-ent.git "tsh version" --asdf-tool-version "17.4.2-fips" --asdf-plugin-gitref "feat-fips"
* Downloading teleport-ent release 0.0.11...
curl: (22) The requested URL returned error: 404
asdf-teleport-ent: Could not download https://cdn.teleport.dev/teleport-ent-v0.0.11-linux-amd64-bin.tar.gz
FAILED: install exited with an error

$ asdf plugin test v1 https://github.com/drootsad/asdf-teleport-ent.git --asdf-tool-version 17.4.2 --asdf-plugin-gitref feat-fips "tsh version"

* Downloading teleport-ent release 0.0.11...
curl: (22) The requested URL returned error: 404
asdf-teleport-ent: Could not download https://cdn.teleport.dev/teleport-ent-v0.0.11-linux-amd64-bin.tar.gz
FAILED: install exited with an error
```