### PR TITLE
fix: Update download URL and add mise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-teleport-ent [![Build](https://github.com/highb/asdf-teleport-ent/actions/workflows/build.yml/badge.svg)](https://github.com/highb/asdf-teleport-ent/actions/workflows/build.yml) [![Lint](https://github.com/highb/asdf-teleport-ent/actions/workflows/lint.yml/badge.svg)](https://github.com/highb/asdf-teleport-ent/actions/workflows/lint.yml)
 
 
-[teleport-ent](https://goteleport.com/docs/server-access/guides/tsh/) plugin for the [asdf version manager](https://asdf-vm.com).
+[teleport-ent](https://goteleport.com/docs/server-access/guides/tsh/) plugin for the [asdf version manager](https://asdf-vm.com) and [mise](https://mise.jdx.dev/).
 
 </div>
 
@@ -21,6 +21,8 @@
 - `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install
+
+## With asdf
 
 Plugin:
 
@@ -58,14 +60,51 @@ tctl version
 teleport version
 ```
 
-Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to
-install & manage versions.
+## With mise
+
+Plugin:
+
+```shell
+mise plugin install teleport-ent
+# or
+mise plugin install teleport-ent https://github.com/highb/asdf-teleport-ent.git
+```
+
+teleport-ent:
+
+```shell
+# Show all installable versions
+mise ls-remote teleport-ent
+
+# Install latest version
+mise install teleport-ent@latest
+
+# Install specific version
+mise install teleport-ent@14.2.2
+
+# Set a version globally (on your ~/.tool-versions file)
+mise global teleport-ent@latest
+
+# Set a version locally for the current directory and all sub-directories
+# This will also create a .tool-versions file which can be checked in to source control.
+mise local teleport-ent@14.2.2
+
+# Set a version for the current shell
+mise shell teleport-ent@14.2.2
+
+# Now teleport-ent commands are available
+tsh version
+tctl version
+teleport version
+```
+
+Check [asdf](https://github.com/asdf-vm/asdf) or [mise](https://mise.jdx.dev/) documentation for more instructions on how to install & manage versions.
 
 # Why?
 
 When testing out version upgrades on Teleport, I frequently found myself jumping between
 tsh/tctl versions and decided that I didn't want to manage a bunch of symlinks manually
-so I made an asdf plugin.
+so I made an asdf plugin. This plugin works with both asdf and mise version managers.
 
 *I do not work for Gravitational* so this does not come with any support guarantees, but
 please feel free to open a PR if you find a version that you need is missing or you need

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 GH_REPO="https://github.com/gravitational/teleport/"
-REPO="https://cdn.teleport.dev"
+REPO="https://get.gravitational.com"
 TOOL_NAME="teleport-ent"
 TOOL_TEST="tsh version"
 OS="${OS:-unknown}"


### PR DESCRIPTION
- Fix download URL from cdn.teleport.dev to get.gravitational.com for newer teleport-ent versions
- Add mise version manager support with complete command examples in README
- Update plugin description to mention both asdf and mise compatibility